### PR TITLE
Build container for testing

### DIFF
--- a/src/Config/ContainerConfiguration.php
+++ b/src/Config/ContainerConfiguration.php
@@ -104,9 +104,9 @@ final class ContainerConfiguration
         return 'Project' . md5(implode(';', array_merge($this->files, $this->paths))) . 'ServiceContainer';
     }
 
-    public function getDumpFile(): string
+    public function getDumpFile(string $prefix = ''): string
     {
-        return $this->dumpDir . DIRECTORY_SEPARATOR . $this->getClassName() . '.php';
+        return $this->dumpDir . DIRECTORY_SEPARATOR . $prefix . $this->getClassName() . '.php';
     }
 
     public function getDumpOptions(): array

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -6,6 +6,7 @@ namespace Lcobucci\DependencyInjection;
 use Lcobucci\DependencyInjection\Compiler\ParameterBag;
 use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
 use Lcobucci\DependencyInjection\Generators\Xml as XmlGenerator;
+use Lcobucci\DependencyInjection\Testing\MakeServicesPublic;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -140,14 +141,6 @@ final class ContainerBuilder implements Builder
         return $this;
     }
 
-    protected function createDumpCache(): ConfigCache
-    {
-        return new ConfigCache(
-            $this->config->getDumpFile(),
-            $this->parameterBag->get('app.devmode')
-        );
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -155,7 +148,21 @@ final class ContainerBuilder implements Builder
     {
         return $this->generator->generate(
             $this->config,
-            $this->createDumpCache()
+            new ConfigCache(
+                $this->config->getDumpFile(),
+                $this->parameterBag->get('app.devmode')
+            )
+        );
+    }
+
+    public function getTestContainer(): ContainerInterface
+    {
+        $config = clone $this->config;
+        $config->addPass(new MakeServicesPublic());
+
+        return $this->generator->generate(
+            $config,
+            new ConfigCache($config->getDumpFile('test_'), true)
         );
     }
 }

--- a/src/Testing/MakeServicesPublic.php
+++ b/src/Testing/MakeServicesPublic.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection\Testing;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class MakeServicesPublic implements CompilerPassInterface
+{
+    /**
+     * You can modify the container here before it is dumped to PHP code.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            $definition->setPublic(true);
+        }
+
+        foreach ($container->getAliases() as $alias) {
+            $alias->setPublic(true);
+        }
+    }
+}

--- a/test/Config/ContainerConfigurationTest.php
+++ b/test/Config/ContainerConfigurationTest.php
@@ -225,6 +225,24 @@ final class ContainerConfigurationTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
+     * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration::getDumpFile
+     *
+     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration::__construct
+     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration::getClassName
+     */
+    public function getDumpFileCanAlsoAddPrefixForTheFile(): void
+    {
+        $config = new ContainerConfiguration();
+
+        self::assertEquals(
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'test_Project' . md5('') . 'ServiceContainer.php',
+            $config->getDumpFile('test_')
+        );
+    }
+
+    /**
+     * @test
+     *
      * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration::getDumpOptions
      *
      * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration::__construct

--- a/test/Testing/MakeServicesPublicTest.php
+++ b/test/Testing/MakeServicesPublicTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection\Testing;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class MakeServicesPublicTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\DependencyInjection\Testing\MakeServicesPublic
+     */
+    public function processShouldMakeAllDefinedServicesPublic(): void
+    {
+        $service1 = new Definition('resource');
+
+        $service2 = new Definition('resource');
+        $service2->setPublic(false);
+
+        $builder = new ContainerBuilder();
+        $builder->setDefinition('one', $service1);
+        $builder->setDefinition('two', $service2);
+
+        $pass = new MakeServicesPublic();
+        $pass->process($builder);
+
+        self::assertTrue($service1->isPublic());
+        self::assertTrue($service2->isPublic());
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\DependencyInjection\Testing\MakeServicesPublic
+     */
+    public function processShouldMakeAllDefinedAliasesPublic(): void
+    {
+        $service = new Definition('resource');
+        $alias   = new Alias('one', false);
+
+        $builder = new ContainerBuilder();
+        $builder->setDefinition('one', $service);
+        $builder->setAlias('two', $alias);
+
+        $pass = new MakeServicesPublic();
+        $pass->process($builder);
+
+        self::assertTrue($service->isPublic());
+        self::assertTrue($alias->isPublic());
+    }
+}


### PR DESCRIPTION
Mostly used for integration tests, so that we can easily override services.