### PR TITLE
Implement delayed passes

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -32,6 +32,12 @@ interface Builder
         string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION
     ): Builder;
 
+    public function addDelayedPass(
+        string $className,
+        array $constructArguments = [],
+        string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION
+    ): Builder;
+
     /**
      * Mark the container to be used as development mode
      */

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6,6 +6,7 @@ namespace Lcobucci\DependencyInjection;
 use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyBuilder;
 use Symfony\Component\DependencyInjection\Dumper\DumperInterface;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
@@ -52,8 +53,16 @@ final class Compiler
         SymfonyBuilder $container,
         ContainerConfiguration $config
     ): void {
-        foreach ($config->getPassList() as $pass) {
-            $container->addCompilerPass(...$pass);
+        foreach ($config->getPassList() as $passConfig) {
+            [$pass, $type] = $passConfig;
+
+            if (! $pass instanceof CompilerPassInterface) {
+                [$className, $constructArguments] = $pass;
+
+                $pass = new $className(...$constructArguments);
+            }
+
+            $container->addCompilerPass($pass, $type);
         }
     }
 

--- a/src/Config/ContainerConfiguration.php
+++ b/src/Config/ContainerConfiguration.php
@@ -52,7 +52,7 @@ final class ContainerConfiguration
         return $this->files;
     }
 
-    public function addFile(string $file)
+    public function addFile(string $file): void
     {
         $this->files[] = $file;
     }
@@ -65,7 +65,7 @@ final class ContainerConfiguration
     public function addPass(
         CompilerPassInterface $pass,
         string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION
-    ) {
+    ): void {
         $this->passList[] = [$pass, $type];
     }
 
@@ -74,7 +74,7 @@ final class ContainerConfiguration
         return $this->paths;
     }
 
-    public function addPath(string $path)
+    public function addPath(string $path): void
     {
         $this->paths[] = $path;
     }
@@ -84,7 +84,7 @@ final class ContainerConfiguration
         return $this->baseClass;
     }
 
-    public function setBaseClass(string $baseClass)
+    public function setBaseClass(string $baseClass): void
     {
         $this->baseClass = $baseClass;
     }
@@ -94,7 +94,7 @@ final class ContainerConfiguration
         return $this->dumpDir;
     }
 
-    public function setDumpDir(string $dumpDir)
+    public function setDumpDir(string $dumpDir): void
     {
         $this->dumpDir = rtrim($dumpDir, DIRECTORY_SEPARATOR);
     }

--- a/src/Config/ContainerConfiguration.php
+++ b/src/Config/ContainerConfiguration.php
@@ -69,6 +69,14 @@ final class ContainerConfiguration
         $this->passList[] = [$pass, $type];
     }
 
+    public function addDelayedPass(
+        string $className,
+        array $constructArguments,
+        string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION
+    ): void {
+        $this->passList[] = [[$className, $constructArguments], $type];
+    }
+
     public function getPaths(): array
     {
         return $this->paths;

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -82,6 +82,16 @@ final class ContainerBuilder implements Builder
         return $this;
     }
 
+    public function addDelayedPass(
+        string $className,
+        array $constructArguments = [],
+        string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION
+    ): Builder {
+        $this->config->addDelayedPass($className, $constructArguments, $type);
+
+        return $this;
+    }
+
     public function useDevelopmentMode(): Builder
     {
         $this->parameterBag->set('app.devmode', true);

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -123,7 +123,7 @@ final class ContainerBuilder implements Builder
             $this->config,
             new ConfigCache(
                 $this->config->getDumpFile(),
-                $this->parameterBag->get('app.devmode')
+                (bool) $this->parameterBag->get('app.devmode')
             )
         );
     }

--- a/test/Config/ContainerConfigurationTest.php
+++ b/test/Config/ContainerConfigurationTest.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Lcobucci\DependencyInjection\Config;
 
+use Lcobucci\DependencyInjection\Compiler\ParameterBag;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
 /**
  * @author Luís Otávio Cobucci Oblonczyk <lcobucci@gmail.com>
@@ -98,6 +100,25 @@ final class ContainerConfigurationTest extends \PHPUnit\Framework\TestCase
         $config->addPass($this->pass);
 
         self::assertAttributeSame([[$this->pass, 'beforeOptimization']], 'passList', $config);
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration::addDelayedPass
+     *
+     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration::__construct
+     */
+    public function addDelayedPassShouldAppendANewCompilerPassToTheList(): void
+    {
+        $config = new ContainerConfiguration();
+        $config->addDelayedPass(ParameterBag::class, ['a' => 'b']);
+
+        self::assertAttributeSame(
+            [[[ParameterBag::class, ['a' => 'b']], 'beforeOptimization']],
+            'passList',
+            $config
+        );
     }
 
     /**

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -144,6 +144,26 @@ final class ContainerBuilderTest extends \PHPUnit\Framework\TestCase
     /**
      * @test
      *
+     * @covers \Lcobucci\DependencyInjection\ContainerBuilder::addDelayedPass
+     *
+     * @uses \Lcobucci\DependencyInjection\ContainerBuilder::__construct
+     * @uses \Lcobucci\DependencyInjection\ContainerBuilder::setDefaultConfiguration
+     *
+     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration
+     * @uses \Lcobucci\DependencyInjection\Compiler\ParameterBag
+     */
+    public function addDelayedPassShouldAppendANewHandlerOnTheListAndReturnSelf(): void
+    {
+        $builder = new ContainerBuilder($this->config, $this->generator, $this->parameterBag);
+        $pass    = get_class($this->createMock(CompilerPassInterface::class));
+
+        self::assertSame($builder, $builder->addDelayedPass($pass));
+        self::assertContains([[$pass, []], PassConfig::TYPE_BEFORE_OPTIMIZATION], $this->config->getPassList());
+    }
+
+    /**
+     * @test
+     *
      * @covers \Lcobucci\DependencyInjection\ContainerBuilder::setDumpDir
      *
      * @uses \Lcobucci\DependencyInjection\ContainerBuilder::__construct


### PR DESCRIPTION
With this the compiler passes are only autoloaded and instantiated during the compilation of the container, so we avoid wasting resources when container is already cached.