### PR TITLE
Fix freshness check

### DIFF
--- a/src/Compiler/DumpXmlContainer.php
+++ b/src/Compiler/DumpXmlContainer.php
@@ -23,7 +23,7 @@ final class DumpXmlContainer implements CompilerPassInterface
 
     public function process(ContainerBuilder $container): void
     {
-        if (! $container->getParameter('app.devmode') || ! $this->configCache->isFresh()) {
+        if (! $container->getParameter('app.devmode') || $this->configCache->isFresh()) {
             return;
         }
 

--- a/test/Compiler/DumpXmlContainerTest.php
+++ b/test/Compiler/DumpXmlContainerTest.php
@@ -49,10 +49,10 @@ final class DumpXmlContainerTest extends TestCase
      * @covers \Lcobucci\DependencyInjection\Compiler\DumpXmlContainer::__construct
      * @covers \Lcobucci\DependencyInjection\Compiler\DumpXmlContainer::process
      */
-    public function processShouldBeSkippedWhenCacheIsNotFresh(): void
+    public function processShouldBeSkippedWhenCacheIsFresh(): void
     {
         $this->configCache->method('isFresh')
-                          ->willReturn(false);
+                          ->willReturn(true);
 
         $this->configCache->expects($this->never())
                           ->method('write');
@@ -77,7 +77,7 @@ final class DumpXmlContainerTest extends TestCase
         );
 
         $this->configCache->method('isFresh')
-                          ->willReturn(true);
+                          ->willReturn(false);
 
         $this->configCache->expects($this->once())
                           ->method('write')


### PR DESCRIPTION
Refering back to Symfony Dumper the check states that if the Cache is
not fresh it should rewrite the file. Our code did the opposite.