### PR TITLE
Dump container in multiple files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for mutation"; exit 1; fi
       script:
-        - ./vendor/bin/infection -s --min-msi=88 --min-covered-msi=100
+        - ./vendor/bin/infection -s --min-msi=95 --min-covered-msi=95 --threads=4
 
     - stage: Quality
       env: STATIC_ANALYSIS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,11 @@ jobs:
       install: travis_retry composer update --prefer-lowest
 
     - stage: Test
-      env: DEPENDENCIES=stable
-      install: travis_retry composer update --prefer-stable
+      env: DEPENDENCIES=dev
+      if: type = cron
+      install:
+        - composer config minimum-stability dev
+        - travis_retry composer update
 
     - stage: Quality
       env: TEST_COVERAGE=1

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "license": [
         "BSD-3-Clause"
     ],
-    "minimum-stability": "dev",
     "require": {
         "php": "^7.2",
         "symfony/config": "^4.0",

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 namespace Lcobucci\DependencyInjection;
 
 use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
+use RuntimeException;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyBuilder;
-use Symfony\Component\DependencyInjection\Dumper\DumperInterface;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
+use Symfony\Component\Filesystem\Filesystem;
+use function array_pop;
 use function assert;
 use function class_exists;
+use function dirname;
 use function is_array;
 
 final class Compiler
@@ -64,6 +67,9 @@ final class Compiler
         }
     }
 
+    /**
+     * @throws RuntimeException
+     */
     private function updateDump(
         SymfonyBuilder $container,
         ContainerConfiguration $config,
@@ -71,17 +77,56 @@ final class Compiler
     ): void {
         $container->compile();
 
-        $options          = $config->getDumpOptions();
-        $options['file']  = $dump->getPath();
-        $options['debug'] = $container->getParameter('app.devmode');
-
-        $dump->write(
-            $this->getDumper($container)->dump($options),
-            $container->getResources()
+        $this->writeToFiles(
+            $this->getContainerContent($container, $config, $dump),
+            dirname($dump->getPath()) . '/',
+            $dump,
+            $container
         );
     }
 
-    private function getDumper(SymfonyBuilder $container): DumperInterface
+    /**
+     * @return string[]
+     */
+    private function getContainerContent(
+        SymfonyBuilder $container,
+        ContainerConfiguration $config,
+        ConfigCache $dump
+    ): array {
+        $options             = $config->getDumpOptions();
+        $options['file']     = $dump->getPath();
+        $options['debug']    = $container->getParameter('app.devmode');
+        $options['as_files'] = true;
+
+        $content = $this->getDumper($container)->dump($options);
+        assert(is_array($content));
+
+        return $content;
+    }
+
+    /**
+     * @param string[] $content
+     *
+     * @throws RuntimeException
+     */
+    private function writeToFiles(
+        array $content,
+        string $baseDir,
+        ConfigCache $dump,
+        SymfonyBuilder $container
+    ): void {
+        $rootCode = array_pop($content);
+
+        $filesystem = new Filesystem();
+
+        foreach ($content as $file => $code) {
+            $filesystem->dumpFile($baseDir . $file, $code);
+        }
+
+        $dump->write($rootCode, $container->getResources());
+    }
+
+    private function getDumper(SymfonyBuilder $container): PhpDumper
     {
         $dumper = new PhpDumper($container);
 

--- a/test/CompilerTest.php
+++ b/test/CompilerTest.php
@@ -1,0 +1,108 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection;
+
+use Generator as PHPGenerator;
+use Lcobucci\DependencyInjection\Compiler\ParameterBag;
+use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
+use Lcobucci\DependencyInjection\Generators\Yaml;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use org\bovigo\vfs\vfsStreamFile;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use function assert;
+use function count;
+use function iterator_to_array;
+use function umask;
+
+final class CompilerTest extends TestCase
+{
+    /**
+     * @var vfsStreamDirectory
+     */
+    private $root;
+
+    /**
+     * @var ContainerConfiguration
+     */
+    private $config;
+
+    /**
+     * @var ConfigCache
+     */
+    private $dump;
+
+    /**
+     * @before
+     */
+    public function configureDependencies(): void
+    {
+        $this->root = vfsStream::setup(
+            'tests',
+            null,
+            ['services.yml' => 'services: { testing: { class: stdClass, public: true } }']
+        );
+
+        $this->config = new ContainerConfiguration(
+            [vfsStream::url('tests/services.yml')],
+            [
+                [new ParameterBag(['app.devmode' => true]), PassConfig::TYPE_BEFORE_OPTIMIZATION],
+            ]
+        );
+
+        $this->dump = new ConfigCache(vfsStream::url('tests/container.php'), false);
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\DependencyInjection\Compiler
+     *
+     * @uses \Lcobucci\DependencyInjection\Compiler\ParameterBag
+     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration
+     * @uses \Lcobucci\DependencyInjection\Generator
+     * @uses \Lcobucci\DependencyInjection\Generators\Yaml
+     */
+    public function compileShouldCreateMultipleFiles(): void
+    {
+        $compiler = new Compiler();
+        $compiler->compile($this->config, $this->dump, new Yaml());
+
+        $expectedFiles = [
+            'removed-ids.php',
+            'getTestingService.php',
+            $this->config->getClassName() . '.php',
+            'container.php',
+            'container.php.meta',
+        ];
+
+        $expectedPermissions = 0666 & ~umask();
+        $generatedFiles      = iterator_to_array($this->getGeneratedFiles($this->root));
+
+        self::assertCount(count($expectedFiles), $generatedFiles);
+
+        foreach ($generatedFiles as $name => $file) {
+            assert($file instanceof vfsStreamFile);
+
+            self::assertContains($name, $expectedFiles);
+            self::assertSame($expectedPermissions, $file->getPermissions());
+        }
+    }
+
+    private function getGeneratedFiles(vfsStreamDirectory $directory): PHPGenerator
+    {
+        foreach ($directory->getChildren() as $child) {
+            if ($child instanceof vfsStreamDirectory) {
+                yield from $this->getGeneratedFiles($child);
+                continue;
+            }
+
+            if ($child->getName() !== 'services.yml') {
+                yield $child->getName() => $child;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This option has been added in `symfony/dependency-injection` v4 and the idea is to reduce the amount of files/classes loaded when the container is initialised, thus reducing memory usage and speeding up things.

More info: https://github.com/symfony/symfony/pull/23678