### PR TITLE
Fix type of the test compiler pass

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -153,7 +153,7 @@ final class ContainerBuilder implements Builder
     public function getTestContainer(): ContainerInterface
     {
         $config = clone $this->config;
-        $config->addPass(new MakeServicesPublic());
+        $config->addPass(new MakeServicesPublic(), PassConfig::TYPE_BEFORE_REMOVING);
 
         return $this->generator->generate(
             $config,

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -321,7 +321,7 @@ final class ContainerBuilderTest extends TestCase
 
         $config = new ContainerConfiguration();
         $config->addPass($this->parameterBag);
-        $config->addPass(new MakeServicesPublic());
+        $config->addPass(new MakeServicesPublic(), PassConfig::TYPE_BEFORE_REMOVING);
 
         $cacheConfig = new ConfigCache($config->getDumpFile('test_'), true);
 


### PR DESCRIPTION
So that it gets executed before of removing private services, which is important for compiler passes that adds new aliases/services and have lower priorities.