### PR TITLE
Use namespaces to avoid class name conflicts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,11 +10,13 @@ Once everything is configured, the builder gives you a fully functional containe
 <?php
 declare(strict_types=1);
 
+namespace Me\MyApplication\DI;
+
 use Lcobucci\DependencyInjection\ContainerBuilder;
 
 // The path to the current file is passed so we can track changes
 // to it and refresh the cache (for development mode)
-$builder = ContainerBuilder::default(__FILE__);
+$builder = ContainerBuilder::default(__FILE__, __NAMESPACE__);
 
 $container = $builder->getContainer();
 
@@ -45,7 +47,7 @@ You may use the following configuration file as inspiration for your projects (u
 <?php
 declare(strict_types=1);
 
-namespace Me\MyApplication;
+namespace Me\MyApplication\DI;
 
 use Lcobucci\DependencyInjection\ContainerBuilder;
 
@@ -54,7 +56,7 @@ use function getenv;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$builder     = ContainerBuilder::default(__FILE__);
+$builder     = ContainerBuilder::default(__FILE__, __NAMESPACE__);
 $projectRoot = dirname(__DIR__);
 
 if (getenv('APPLICATION_MODE', true) === 'development') {

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -33,10 +33,12 @@ final class ContainerBuilder implements Builder
         $this->setDefaultConfiguration();
     }
 
-    public static function default(string $configurationFile): self
-    {
+    public static function default(
+        string $configurationFile,
+        string $namespace
+    ): self {
         return new self(
-            new ContainerConfiguration(),
+            new ContainerConfiguration($namespace),
             new XmlGenerator($configurationFile),
             new ParameterBag()
         );
@@ -148,12 +150,12 @@ final class ContainerBuilder implements Builder
 
     public function getTestContainer(): ContainerInterface
     {
-        $config = clone $this->config;
+        $config = $this->config->withSubNamespace('Tests');
         $config->addPass(new MakeServicesPublic(), PassConfig::TYPE_BEFORE_REMOVING);
 
         return $this->generator->generate(
             $config,
-            new ConfigCache($config->getDumpFile('test_'), true)
+            new ConfigCache($config->getDumpFile(), true)
         );
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -30,15 +30,15 @@ abstract class Generator
     ): ContainerInterface {
         $this->compiler->compile($config, $dump, $this);
 
-        return $this->loadContainer($dump);
+        return $this->loadContainer($config, $dump);
     }
 
-    private function loadContainer(ConfigCache $dump): ContainerInterface
+    private function loadContainer(ContainerConfiguration $config, ConfigCache $dump): ContainerInterface
     {
         require_once $dump->getPath();
-        $className = '\\' . ContainerConfiguration::CLASS_NAME;
+        $className = $config->getClassName();
 
-        return new $className(); // @phpstan-ignore-line (class loaded dynamically and PHPStan can't evaluate that)
+        return new $className();
     }
 
     public function initializeContainer(ContainerConfiguration $config): SymfonyBuilder

--- a/test/Config/ContainerConfigurationTest.php
+++ b/test/Config/ContainerConfigurationTest.php
@@ -41,7 +41,7 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getFilesShouldReturnTheFileList(): void
     {
-        $config = new ContainerConfiguration(['services.xml']);
+        $config = new ContainerConfiguration('Me\\MyApp', ['services.xml']);
 
         self::assertSame(['services.xml'], iterator_to_array($config->getFiles()));
     }
@@ -74,6 +74,7 @@ final class ContainerConfigurationTest extends TestCase
         };
 
         $config = new ContainerConfiguration(
+            'Me\\MyApp',
             ['services.xml'],
             [],
             [],
@@ -91,10 +92,10 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function addFileShouldAppendANewFileToTheList(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->addFile('services.xml');
 
-        self::assertEquals(new ContainerConfiguration(['services.xml']), $config);
+        self::assertEquals(new ContainerConfiguration('Me\\MyApp', ['services.xml']), $config);
     }
 
     /**
@@ -108,7 +109,7 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getPassListShouldReturnTheHandlersList(): void
     {
-        $config = new ContainerConfiguration([], [[$this->pass, 'beforeOptimization']]);
+        $config = new ContainerConfiguration('Me\\MyApp', [], [[$this->pass, 'beforeOptimization']]);
 
         self::assertSame([[$this->pass, 'beforeOptimization']], iterator_to_array($config->getPassList()));
     }
@@ -141,6 +142,7 @@ final class ContainerConfigurationTest extends TestCase
         };
 
         $config = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [[$this->pass, 'beforeOptimization']],
             [],
@@ -164,10 +166,11 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function addPassShouldAppendANewHandlerToTheList(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->addPass($this->pass);
 
         $expected = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [[$this->pass, PassConfig::TYPE_BEFORE_OPTIMIZATION, 0]]
         );
@@ -183,10 +186,11 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function addPassCanReceiveTheTypeAndPriority(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->addPass($this->pass, PassConfig::TYPE_AFTER_REMOVING, 1);
 
         $expected = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [[$this->pass, PassConfig::TYPE_AFTER_REMOVING, 1]]
         );
@@ -202,10 +206,11 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function addDelayedPassShouldAppendANewCompilerPassToTheList(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->addDelayedPass(ParameterBag::class, ['a' => 'b']);
 
         $expected = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [[[ParameterBag::class, ['a' => 'b']], PassConfig::TYPE_BEFORE_OPTIMIZATION, 0]]
         );
@@ -221,10 +226,11 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function addDelayedPassCanReceiveTheTypeAndPriority(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->addDelayedPass(ParameterBag::class, ['a' => 'b'], PassConfig::TYPE_AFTER_REMOVING, 1);
 
         $expected = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [[[ParameterBag::class, ['a' => 'b']], PassConfig::TYPE_AFTER_REMOVING, 1]]
         );
@@ -241,10 +247,11 @@ final class ContainerConfigurationTest extends TestCase
     public function addPackageShouldAppendThePackageConfigurationToTheList(): void
     {
         $package = get_class($this->createMock(Package::class));
-        $config  = new ContainerConfiguration();
+        $config  = new ContainerConfiguration('Me\\MyApp');
         $config->addPackage($package, ['a' => 'b']);
 
         $expected = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [],
             [],
@@ -264,7 +271,7 @@ final class ContainerConfigurationTest extends TestCase
     public function getPackagesShouldReturnAListOfInstantiatedPackages(): void
     {
         $package = $this->createMock(Package::class);
-        $config  = new ContainerConfiguration([], [], [], [[get_class($package), []]]);
+        $config  = new ContainerConfiguration('Me\\MyApp', [], [], [], [[get_class($package), []]]);
 
         self::assertEquals([$package], $config->getPackages());
     }
@@ -279,7 +286,7 @@ final class ContainerConfigurationTest extends TestCase
     public function getPackagesShouldInstantiateThePackagesOnlyOnce(): void
     {
         $packageName = get_class($this->createMock(Package::class));
-        $config      = new ContainerConfiguration([], [], [], [[$packageName, []]]);
+        $config      = new ContainerConfiguration('Me\\MyApp', [], [], [], [[$packageName, []]]);
 
         $createdPackages = $config->getPackages();
 
@@ -295,7 +302,7 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getPathsShouldReturnThePathsList(): void
     {
-        $config = new ContainerConfiguration([], [], ['config']);
+        $config = new ContainerConfiguration('Me\\MyApp', [], [], ['config']);
 
         self::assertEquals(['config'], $config->getPaths());
     }
@@ -308,10 +315,11 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function addPathShouldAppendANewPathToTheList(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->addPath('services');
 
         $expected = new ContainerConfiguration(
+            'Me\\MyApp',
             [],
             [],
             ['services']
@@ -330,7 +338,7 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function setBaseClassShouldChangeTheAttribute(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->setBaseClass('Test');
 
         self::assertSame('Test', $config->getBaseClass());
@@ -345,7 +353,7 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getDumpDirShouldReturnTheAttributeValue(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
 
         self::assertEquals(sys_get_temp_dir(), $config->getDumpDir());
     }
@@ -360,7 +368,7 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function setDumpDirShouldChangeTheAttribute(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->setDumpDir('/test/');
 
         self::assertEquals('/test', $config->getDumpDir());
@@ -375,28 +383,11 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getDumpFileShouldReturnTheFullPathOfDumpFile(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
 
         self::assertEquals(
-            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'AppContainer.php',
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'me_myapp' . DIRECTORY_SEPARATOR . 'AppContainer.php',
             $config->getDumpFile()
-        );
-    }
-
-    /**
-     * @test
-     *
-     * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration::getDumpFile
-     *
-     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration::__construct
-     */
-    public function getDumpFileCanAlsoAddPrefixForTheFile(): void
-    {
-        $config = new ContainerConfiguration();
-
-        self::assertEquals(
-            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'test_AppContainer.php',
-            $config->getDumpFile('test_')
         );
     }
 
@@ -409,9 +400,10 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getDumpOptionsShouldReturnTheDumpingInformation(): void
     {
-        $config  = new ContainerConfiguration();
+        $config  = new ContainerConfiguration('Me\\MyApp');
         $options = [
             'class'        => ContainerConfiguration::CLASS_NAME,
+            'namespace'    => 'Me\\MyApp',
             'hot_path_tag' => 'container.hot_path',
         ];
 
@@ -428,15 +420,33 @@ final class ContainerConfigurationTest extends TestCase
      */
     public function getDumpOptionsShouldIncludeBaseWhenWasConfigured(): void
     {
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp');
         $config->setBaseClass('Test');
 
         $options = [
             'class'        => ContainerConfiguration::CLASS_NAME,
+            'namespace'    => 'Me\\MyApp',
             'base_class'   => 'Test',
             'hot_path_tag' => 'container.hot_path',
         ];
 
         self::assertSame($options, $config->getDumpOptions());
+    }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration::withSubNamespace
+     * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration::getClassName
+     *
+     * @uses \Lcobucci\DependencyInjection\Config\ContainerConfiguration::__construct
+     */
+    public function withAddedNamespaceShouldModifyTheNamespaceOfANewInstanceOnly(): void
+    {
+        $config = new ContainerConfiguration('Me\\MyApp');
+        $other  = $config->withSubNamespace('\\Testing');
+
+        self::assertSame('Me\\MyApp\\AppContainer', $config->getClassName());
+        self::assertSame('Me\\MyApp\\Testing\\AppContainer', $other->getClassName());
     }
 }

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -29,7 +29,7 @@ final class ContainerBuilderTest extends TestCase
     public function configureDependencies(): void
     {
         $this->generator    = $this->getMockForAbstractClass(Generator::class, [], '', false, true, true, ['generate']);
-        $this->config       = new ContainerConfiguration();
+        $this->config       = new ContainerConfiguration('Me\\MyApp');
         $this->parameterBag = new ParameterBag();
     }
 
@@ -47,9 +47,13 @@ final class ContainerBuilderTest extends TestCase
      */
     public function defaultShouldSimplifyTheObjectCreation(): void
     {
-        $expected = new ContainerBuilder(new ContainerConfiguration(), new XmlGenerator(__FILE__), new ParameterBag());
+        $expected = new ContainerBuilder(
+            new ContainerConfiguration('Lcobucci\\DependencyInjection'),
+            new XmlGenerator(__FILE__),
+            new ParameterBag()
+        );
 
-        self::assertEquals($expected, ContainerBuilder::default(__FILE__));
+        self::assertEquals($expected, ContainerBuilder::default(__FILE__, __NAMESPACE__));
     }
 
     /**
@@ -296,11 +300,11 @@ final class ContainerBuilderTest extends TestCase
         $builder   = new ContainerBuilder($this->config, $this->generator, $this->parameterBag);
         $container = $this->createMock(ContainerInterface::class);
 
-        $config = new ContainerConfiguration();
+        $config = new ContainerConfiguration('Me\\MyApp\\Tests');
         $config->addPass($this->parameterBag);
         $config->addPass(new MakeServicesPublic(), PassConfig::TYPE_BEFORE_REMOVING);
 
-        $cacheConfig = new ConfigCache($config->getDumpFile('test_'), true);
+        $cacheConfig = new ConfigCache($config->getDumpFile(), true);
 
         $this->generator->expects(self::once())
                         ->method('generate')

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -38,7 +38,7 @@ final class GeneratorTest extends TestCase
      */
     public function initializeContainerShouldAddTheConfigurationFileAsAResource(): void
     {
-        $container = $this->generator->initializeContainer(new ContainerConfiguration());
+        $container = $this->generator->initializeContainer(new ContainerConfiguration('Me\\MyApp'));
 
         self::assertEquals([new FileResource(__FILE__)], $container->getResources());
     }
@@ -65,6 +65,7 @@ final class GeneratorTest extends TestCase
         );
 
         $config = new ContainerConfiguration(
+            'Me\\MyApp',
             [vfsStream::url('tests/services.yml')],
             [
                 [new ParameterBag(['app.devmode' => true]), PassConfig::TYPE_BEFORE_OPTIMIZATION],


### PR DESCRIPTION
Allowing for applications to build multiple containers using configurations and namespaces.

This breaks BC for making it mandatory and for changing the way the dump directory is used.

### Upgrading

Specify a namespace when creating the container builder. **Tip:** Make sure your config file is namespaced and use `__NAMESPACE__` to create the builder:

```php
declare(strict_types=1);

namespace Me\MyApplication\Config;

use Lcobucci\DependencyInjection\ContainerBuilder;

require __DIR__ . '/../vendor/autoload.php';

// $builder = new ContainerBuilder(); // v5.x initialisation
// $builder = ContainerBuilder::default(__FILE__); // v6.x initialisation
$builder = ContainerBuilder::default(__FILE__, __NAMESPACE__);
```

