### PR TITLE
Deprecate the `default` named constructor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,9 @@
 Setting up the container can be a complicated task.
 In order to make the it easier, we provide a builder. 
 
-The builder is initialised via a named constructor using XML as the default format.
+The builder is initialised via a named constructors, which represent the format of files to be parsed (php, xml, yaml).
+You may use `ContainerBuilder::delegating()` to allow all formats to be used.
+
 Once everything is configured, the builder gives you a fully functional container:
 
 ```php
@@ -16,7 +18,7 @@ use Lcobucci\DependencyInjection\ContainerBuilder;
 
 // The path to the current file is passed so we can track changes
 // to it and refresh the cache (for development mode)
-$builder = ContainerBuilder::default(__FILE__, __NAMESPACE__);
+$builder = ContainerBuilder::xml(__FILE__, __NAMESPACE__);
 
 $container = $builder->getContainer();
 
@@ -27,8 +29,6 @@ $testContainer = $builder->getTestContainer();
 
 ## Available methods
 
-* `ContainerBuilder#setGenerator()`: Modifies the generator to be used.
-    We support the `XML`, `Yaml`, `PHP`, and `Delegating` generators (the latter allows to use all formats together)
 * `ContainerBuilder#addPath()`: Add a base path to find files
 * `ContainerBuilder#addFile()`: Adds a container source file
 * `ContainerBuilder#addPass()`: Adds an instance of a [Compiler Pass](compiler-passes.md) to be processed
@@ -56,7 +56,7 @@ use function getenv;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$builder     = ContainerBuilder::default(__FILE__, __NAMESPACE__);
+$builder     = ContainerBuilder::xml(__FILE__, __NAMESPACE__);
 $projectRoot = dirname(__DIR__);
 
 if (getenv('APPLICATION_MODE', true) === 'development') {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -17,6 +17,8 @@ interface Builder
 
     /**
      * Changes the generator to handle the files
+     *
+     * @deprecated This is deprecated in favour of using the correct naming constructor.
      */
     public function setGenerator(Generator $generator): Builder;
 

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -5,7 +5,6 @@ namespace Lcobucci\DependencyInjection;
 
 use Lcobucci\DependencyInjection\Compiler\ParameterBag;
 use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
-use Lcobucci\DependencyInjection\Generators\Xml as XmlGenerator;
 use Lcobucci\DependencyInjection\Testing\MakeServicesPublic;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -25,13 +24,51 @@ final class ContainerBuilder implements Builder
         $this->setDefaultConfiguration();
     }
 
-    public static function default(
-        string $configurationFile,
-        string $namespace,
-    ): self {
+    /**
+     * @deprecated Use the named constructor according to the generator
+     *
+     * @see ContainerBuilder::xml()
+     * @see ContainerBuilder::yaml()
+     * @see ContainerBuilder::php()
+     * @see ContainerBuilder::delegating()
+     */
+    public static function default(string $configurationFile, string $namespace): self
+    {
+        return self::xml($configurationFile, $namespace);
+    }
+
+    public static function xml(string $configurationFile, string $namespace): self
+    {
         return new self(
             new ContainerConfiguration($namespace),
-            new XmlGenerator($configurationFile),
+            new Generators\Xml($configurationFile),
+            new ParameterBag(),
+        );
+    }
+
+    public static function php(string $configurationFile, string $namespace): self
+    {
+        return new self(
+            new ContainerConfiguration($namespace),
+            new Generators\Php($configurationFile),
+            new ParameterBag(),
+        );
+    }
+
+    public static function yaml(string $configurationFile, string $namespace): self
+    {
+        return new self(
+            new ContainerConfiguration($namespace),
+            new Generators\Yaml($configurationFile),
+            new ParameterBag(),
+        );
+    }
+
+    public static function delegating(string $configurationFile, string $namespace): self
+    {
+        return new self(
+            new ContainerConfiguration($namespace),
+            new Generators\Delegating($configurationFile),
             new ParameterBag(),
         );
     }

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -6,7 +6,6 @@ namespace Lcobucci\DependencyInjection;
 use Lcobucci\DependencyInjection\Compiler\ParameterBag;
 use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
 use Lcobucci\DependencyInjection\Config\Package;
-use Lcobucci\DependencyInjection\Generators\Xml as XmlGenerator;
 use Lcobucci\DependencyInjection\Testing\MakeServicesPublic;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -43,20 +42,36 @@ final class ContainerBuilderTest extends TestCase
 
     /**
      * @test
+     * @dataProvider supportedFormats
      *
      * @covers ::default
+     * @covers ::xml
+     * @covers ::delegating
+     * @covers ::php
+     * @covers ::yaml
      * @covers ::__construct
      * @covers ::setDefaultConfiguration
      */
-    public function defaultShouldSimplifyTheObjectCreation(): void
+    public function namedConstructorsShouldSimplifyTheObjectCreation(string $method, Generator $generator): void
     {
         $expected = new ContainerBuilder(
             new ContainerConfiguration('Lcobucci\\DependencyInjection'),
-            new XmlGenerator(__FILE__),
+            $generator,
             new ParameterBag(),
         );
 
-        self::assertEquals($expected, ContainerBuilder::default(__FILE__, __NAMESPACE__));
+        // @phpstan-ignore-next-line
+        self::assertEquals($expected, ContainerBuilder::$method(__FILE__, __NAMESPACE__));
+    }
+
+    /** @return iterable<string, array{string, Generator}> */
+    public function supportedFormats(): iterable
+    {
+        yield 'default' => ['default', new Generators\Xml(__FILE__)];
+        yield 'xml' => ['xml', new Generators\Xml(__FILE__)];
+        yield 'yaml' => ['yaml', new Generators\Yaml(__FILE__)];
+        yield 'php' => ['php', new Generators\Php(__FILE__)];
+        yield 'delegating' => ['delegating', new Generators\Delegating(__FILE__)];
     }
 
     /**


### PR DESCRIPTION
This introduces a more explicit configuration for the format of input files to parse and generate the container.

The name `default` is quite ambiguous and its behaviour could be changed, affecting users for no good reasons.