### PR TITLE
Inline service factories when in production mode

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -79,7 +79,7 @@ final class ContainerBuilder implements Builder
     private function setDefaultConfiguration(): void
     {
         $this->parameterBag->set('app.devmode', false);
-        $this->parameterBag->set('container.dumper.inline_factories', false);
+        $this->parameterBag->set('container.dumper.inline_factories', true);
         $this->parameterBag->set('container.dumper.inline_class_loader', true);
 
         $this->config->addPass($this->parameterBag);
@@ -132,6 +132,7 @@ final class ContainerBuilder implements Builder
     public function useDevelopmentMode(): Builder
     {
         $this->parameterBag->set('app.devmode', true);
+        $this->parameterBag->set('container.dumper.inline_factories', false);
         $this->parameterBag->set('container.dumper.inline_class_loader', false);
 
         return $this;

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -90,7 +90,7 @@ final class ContainerBuilderTest extends TestCase
         self::assertNotEmpty($this->config->getPassList());
         self::assertFalse($this->parameterBag->get('app.devmode'));
         self::assertTrue($this->parameterBag->get('container.dumper.inline_class_loader'));
-        self::assertFalse($this->parameterBag->get('container.dumper.inline_factories'));
+        self::assertTrue($this->parameterBag->get('container.dumper.inline_factories'));
     }
 
     /**


### PR DESCRIPTION
This makes the OPCache more efficient by decreasing the number of files to be managed by that layer.