### PR TITLE
Allow users to customise Symfony's `ContainerBuilder`

### DIFF
--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -9,6 +9,7 @@ use Lcobucci\DependencyInjection\Testing\MakeServicesPublic;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use function assert;
@@ -37,38 +38,54 @@ final class ContainerBuilder implements Builder
         return self::xml($configurationFile, $namespace);
     }
 
-    public static function xml(string $configurationFile, string $namespace): self
-    {
+    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    public static function xml(
+        string $configurationFile,
+        string $namespace,
+        ?string $builderClass = null,
+    ): self {
         return new self(
             new ContainerConfiguration($namespace),
-            new Generators\Xml($configurationFile),
+            new Generators\Xml($configurationFile, $builderClass),
             new ParameterBag(),
         );
     }
 
-    public static function php(string $configurationFile, string $namespace): self
-    {
+    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    public static function php(
+        string $configurationFile,
+        string $namespace,
+        ?string $builderClass = null,
+    ): self {
         return new self(
             new ContainerConfiguration($namespace),
-            new Generators\Php($configurationFile),
+            new Generators\Php($configurationFile, $builderClass),
             new ParameterBag(),
         );
     }
 
-    public static function yaml(string $configurationFile, string $namespace): self
-    {
+    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    public static function yaml(
+        string $configurationFile,
+        string $namespace,
+        ?string $builderClass = null,
+    ): self {
         return new self(
             new ContainerConfiguration($namespace),
-            new Generators\Yaml($configurationFile),
+            new Generators\Yaml($configurationFile, $builderClass),
             new ParameterBag(),
         );
     }
 
-    public static function delegating(string $configurationFile, string $namespace): self
-    {
+    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    public static function delegating(
+        string $configurationFile,
+        string $namespace,
+        ?string $builderClass = null,
+    ): self {
         return new self(
             new ContainerConfiguration($namespace),
-            new Generators\Delegating($configurationFile),
+            new Generators\Delegating($configurationFile, $builderClass),
             new ParameterBag(),
         );
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -13,10 +13,16 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class Generator
 {
     private Compiler $compiler;
+    /** @var class-string<SymfonyBuilder> */
+    private string $builderClass;
 
-    public function __construct(private string $configurationFile)
-    {
-        $this->compiler = new Compiler();
+    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    public function __construct(
+        private string $configurationFile,
+        ?string $builderClass = null,
+    ) {
+        $this->compiler     = new Compiler();
+        $this->builderClass = $builderClass ?? SymfonyBuilder::class;
     }
 
     /**
@@ -41,7 +47,7 @@ abstract class Generator
 
     public function initializeContainer(ContainerConfiguration $config): SymfonyBuilder
     {
-        $container = new SymfonyBuilder();
+        $container = new $this->builderClass();
         $container->addResource(new FileResource($this->configurationFile));
 
         $loader = $this->getLoader($container, $config->getPaths());

--- a/test/CompilerTest.php
+++ b/test/CompilerTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\Container;
 
 use function bin2hex;
 use function count;
@@ -166,6 +167,23 @@ final class CompilerTest extends TestCase
         $generatedFiles = iterator_to_array($this->getGeneratedFiles());
 
         self::assertCount(1, $generatedFiles);
+    }
+
+    /** @test */
+    public function compileShouldUseCustomContainerBuilders(): void
+    {
+        $compiler = new Compiler();
+        $compiler->compile(
+            $this->config,
+            $this->dump,
+            new Yaml(__FILE__, CustomContainerBuilderForTests::class),
+        );
+
+        $container = include $this->dumpDir . '/AppContainer.php';
+
+        self::assertInstanceOf(Container::class, $container);
+        self::assertTrue($container->hasParameter('built-with-very-special-builder'));
+        self::assertTrue($container->getParameter('built-with-very-special-builder'));
     }
 
     /** @return PHPGenerator<string, SplFileInfo> */

--- a/test/CompilerTest.php
+++ b/test/CompilerTest.php
@@ -16,15 +16,11 @@ use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Container;
 
-use function bin2hex;
 use function count;
-use function exec;
 use function file_get_contents;
 use function file_put_contents;
 use function iterator_to_array;
 use function mkdir;
-use function random_bytes;
-use function realpath;
 
 /**
  * @covers \Lcobucci\DependencyInjection\Compiler
@@ -53,7 +49,7 @@ final class CompilerTest extends TestCase
     public function configureDependencies(): void
     {
         vfsStream::setup(
-            'tests',
+            'tests-compilation',
             null,
             ['services.yml' => 'services: { testing: { class: stdClass } }'],
         );
@@ -67,8 +63,8 @@ final class CompilerTest extends TestCase
         $this->dump    = new ConfigCache($this->dumpDir . '/AppContainer.php', false);
 
         $this->config = new ContainerConfiguration(
-            'Me\\MyApp',
-            [vfsStream::url('tests/services.yml')],
+            'Me\\CompilationTest',
+            [vfsStream::url('tests-compilation/services.yml')],
             [
                 [$this->parameters, PassConfig::TYPE_BEFORE_OPTIMIZATION],
                 [[MakeServicesPublic::class, []], PassConfig::TYPE_BEFORE_OPTIMIZATION],
@@ -80,16 +76,10 @@ final class CompilerTest extends TestCase
 
     private function createDumpDirectory(): string
     {
-        $dir = __DIR__ . '/../tmp/' . bin2hex(random_bytes(5)) . '/me_myapp';
+        $dir = vfsStream::url('tests-compilation/tmp/me_myapp');
         mkdir($dir, 0777, true);
 
         return $dir;
-    }
-
-    /** @after */
-    public function cleanUpDumpDirectory(): void
-    {
-        exec('rm -rf ' . realpath($this->dumpDir . '/../../'));
     }
 
     /** @test */
@@ -143,7 +133,7 @@ final class CompilerTest extends TestCase
     public function compileShouldAllowForLazyServices(): void
     {
         file_put_contents(
-            vfsStream::url('tests/services.yml'),
+            vfsStream::url('tests-compilation/services.yml'),
             'services: { testing: { class: stdClass, lazy: true } }',
         );
 

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -52,8 +52,11 @@ final class ContainerBuilderTest extends TestCase
      * @covers ::__construct
      * @covers ::setDefaultConfiguration
      */
-    public function namedConstructorsShouldSimplifyTheObjectCreation(string $method, Generator $generator): void
-    {
+    public function namedConstructorsShouldSimplifyTheObjectCreation(
+        string $method,
+        Generator $generator,
+        ?string $builderClass = null,
+    ): void {
         $expected = new ContainerBuilder(
             new ContainerConfiguration('Lcobucci\\DependencyInjection'),
             $generator,
@@ -61,10 +64,10 @@ final class ContainerBuilderTest extends TestCase
         );
 
         // @phpstan-ignore-next-line
-        self::assertEquals($expected, ContainerBuilder::$method(__FILE__, __NAMESPACE__));
+        self::assertEquals($expected, ContainerBuilder::$method(__FILE__, __NAMESPACE__, $builderClass));
     }
 
-    /** @return iterable<string, array{string, Generator}> */
+    /** @return iterable<string, array{string, Generator, 2?: class-string<\Symfony\Component\DependencyInjection\ContainerBuilder>}> */
     public function supportedFormats(): iterable
     {
         yield 'default' => ['default', new Generators\Xml(__FILE__)];
@@ -72,6 +75,30 @@ final class ContainerBuilderTest extends TestCase
         yield 'yaml' => ['yaml', new Generators\Yaml(__FILE__)];
         yield 'php' => ['php', new Generators\Php(__FILE__)];
         yield 'delegating' => ['delegating', new Generators\Delegating(__FILE__)];
+
+        yield 'xml with custom builder' => [
+            'xml',
+            new Generators\Xml(__FILE__, CustomContainerBuilderForTests::class),
+            CustomContainerBuilderForTests::class,
+        ];
+
+        yield 'yaml with custom builder' => [
+            'yaml',
+            new Generators\Yaml(__FILE__, CustomContainerBuilderForTests::class),
+            CustomContainerBuilderForTests::class,
+        ];
+
+        yield 'php with custom builder' => [
+            'php',
+            new Generators\Php(__FILE__, CustomContainerBuilderForTests::class),
+            CustomContainerBuilderForTests::class,
+        ];
+
+        yield 'delegating with custom builder' => [
+            'delegating',
+            new Generators\Delegating(__FILE__, CustomContainerBuilderForTests::class),
+            CustomContainerBuilderForTests::class,
+        ];
     }
 
     /**

--- a/test/CustomContainerBuilderForTests.php
+++ b/test/CustomContainerBuilderForTests.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyBuilder;
+
+final class CustomContainerBuilderForTests extends SymfonyBuilder
+{
+    public function compile(bool $resolveEnvPlaceholders = false): void
+    {
+        $this->parameterBag->set('built-with-very-special-builder', true);
+
+        parent::compile($resolveEnvPlaceholders);
+    }
+}

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -79,19 +79,19 @@ final class GeneratorTest extends TestCase
     public function generateShouldCompileAndLoadTheContainer(): void
     {
         vfsStream::setup(
-            'tests',
+            'tests-generation',
             null,
             ['services.yml' => 'services: { testing: { class: stdClass, public: true } }'],
         );
 
         $config = new ContainerConfiguration(
-            'Me\\MyApp',
-            [vfsStream::url('tests/services.yml')],
+            'Me\\GenerationTest',
+            [vfsStream::url('tests-generation/services.yml')],
             [
                 [new ParameterBag(['app.devmode' => true]), PassConfig::TYPE_BEFORE_OPTIMIZATION],
                 [
                     new DumpXmlContainer(
-                        new ConfigCache(vfsStream::url('tests/dump.xml'), true),
+                        new ConfigCache(vfsStream::url('tests-generation/dump.xml'), true),
                     ),
                     PassConfig::TYPE_AFTER_REMOVING,
                     -255,
@@ -99,7 +99,7 @@ final class GeneratorTest extends TestCase
             ],
         );
 
-        $dump = new ConfigCache(vfsStream::url('tests/container.php'), false);
+        $dump = new ConfigCache(vfsStream::url('tests-generation/container.php'), false);
 
         $this->generator->method('getLoader')->willReturnCallback(
             static function (SymfonyBuilder $container, array $paths): YamlFileLoader {
@@ -113,6 +113,6 @@ final class GeneratorTest extends TestCase
         $container = $this->generator->generate($config, $dump);
 
         self::assertInstanceOf(stdClass::class, $container->get('testing'));
-        self::assertFileExists(vfsStream::url('tests/dump.xml'));
+        self::assertFileExists(vfsStream::url('tests-generation/dump.xml'));
     }
 }

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -53,6 +53,25 @@ final class GeneratorTest extends TestCase
      * @test
      *
      * @covers ::__construct
+     * @covers ::initializeContainer
+     */
+    public function initializeContainerCanOptionallyUseACustomClass(): void
+    {
+        $generator = $this->getMockForAbstractClass(
+            Generator::class,
+            [__FILE__, CustomContainerBuilderForTests::class],
+        );
+
+        self::assertInstanceOf(
+            CustomContainerBuilderForTests::class,
+            $generator->initializeContainer(new ContainerConfiguration('Me\\MyApp')),
+        );
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
      * @covers ::generate
      * @covers ::initializeContainer
      * @covers ::loadContainer


### PR DESCRIPTION
Under certain conditions, users might be interested in extending the container builder to modify its behaviour in the way that compiler passes aren't able to do.