### PR TITLE
Expose and fix incorrect assertion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ vendor/composer/installed.json: composer.json composer.lock
 
 .PHONY: phpunit
 phpunit:
-	@vendor/bin/phpunit
+	@php -dzend.assertions=1 vendor/bin/phpunit
 
 .PHONY: infection
 infection:

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -44,7 +44,7 @@ abstract class Generator
     {
         require_once $dump->getPath();
         $className = $config->getClassName();
-        assert(is_a($className, ContainerInterface::class));
+        assert(is_a($className, ContainerInterface::class, true));
 
         return new $className();
     }


### PR DESCRIPTION
This change intends to fix a fatal error happening when `zend.assertions=1` is defined in the INI settings