### PR TITLE
Fix generation of containers using a base class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ infection:
 
 .PHONY: phpcbf
 phpcbf:
-	@vendor/bin/phpcbf --parallel=$(PARALLELISM)
+	@vendor/bin/phpcbf --parallel=$(PARALLELISM) || true
 
 .PHONY: phpcs
 phpcs:

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,12 @@
     },
     "config": {
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "infection/extension-installer": true,
+            "phpstan/extension-installer": true,
+            "ocramius/package-versions": true
+        }
     }
 }

--- a/src/Config/ContainerConfiguration.php
+++ b/src/Config/ContainerConfiguration.php
@@ -176,7 +176,7 @@ final class ContainerConfiguration
 
     public function setBaseClass(string $baseClass): void
     {
-        $this->baseClass = $baseClass;
+        $this->baseClass = '\\' . ltrim($baseClass, '\\');
     }
 
     public function withSubNamespace(string $namespace): self

--- a/test/CompilationWithBaseClassTest.php
+++ b/test/CompilationWithBaseClassTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Lcobucci\DependencyInjection\ContainerBuilder
+ * @covers \Lcobucci\DependencyInjection\Compiler
+ * @covers \Lcobucci\DependencyInjection\Compiler\ParameterBag
+ * @covers \Lcobucci\DependencyInjection\Config\ContainerConfiguration
+ * @covers \Lcobucci\DependencyInjection\Generator
+ * @covers \Lcobucci\DependencyInjection\Generators\Xml
+ * @covers \Lcobucci\DependencyInjection\Testing\MakeServicesPublic
+ */
+final class CompilationWithBaseClassTest extends TestCase
+{
+    use GeneratesDumpDirectory;
+
+    private const DI_NAMESPACE = 'Lcobucci\\DiTests\\BaseClass';
+
+    /** @test */
+    public function containerCanHaveACustomBaseClass(): void
+    {
+        $container = ContainerBuilder::default(__FILE__, self::DI_NAMESPACE)
+            ->setBaseClass(ContainerForTests::class)
+            ->setDumpDir($this->dumpDirectory)
+            ->getContainer();
+
+        self::assertInstanceOf(ContainerForTests::class, $container);
+    }
+}

--- a/test/Config/ContainerConfigurationTest.php
+++ b/test/Config/ContainerConfigurationTest.php
@@ -342,7 +342,7 @@ final class ContainerConfigurationTest extends TestCase
         $config = new ContainerConfiguration('Me\\MyApp');
         $config->setBaseClass('Test');
 
-        self::assertSame('Test', $config->getBaseClass());
+        self::assertSame('\\Test', $config->getBaseClass());
     }
 
     /**
@@ -427,7 +427,7 @@ final class ContainerConfigurationTest extends TestCase
         $options = [
             'class'        => ContainerConfiguration::CLASS_NAME,
             'namespace'    => 'Me\\MyApp',
-            'base_class'   => 'Test',
+            'base_class'   => '\\Test',
             'hot_path_tag' => 'container.hot_path',
         ];
 

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -208,7 +208,7 @@ final class ContainerBuilderTest extends TestCase
         $builder = new ContainerBuilder($this->config, $this->generator, $this->parameterBag);
 
         self::assertSame($builder, $builder->setBaseClass('Test'));
-        self::assertEquals('Test', $this->config->getBaseClass());
+        self::assertEquals('\\Test', $this->config->getBaseClass());
     }
 
     /**

--- a/test/ContainerForTests.php
+++ b/test/ContainerForTests.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Container;
+
+abstract class ContainerForTests extends Container
+{
+}

--- a/test/GeneratesDumpDirectory.php
+++ b/test/GeneratesDumpDirectory.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Lcobucci\DependencyInjection;
+
+use function assert;
+use function exec;
+use function is_string;
+use function mkdir;
+use function tempnam;
+use function unlink;
+
+trait GeneratesDumpDirectory
+{
+    private string $dumpDirectory;
+
+    /** @before */
+    public function createDumpDir(): void
+    {
+        mkdir(__DIR__ . '/../tmp');
+
+        $tempName = tempnam(__DIR__ . '/../tmp', 'lcobucci-di-builder');
+        assert(is_string($tempName));
+
+        $this->dumpDirectory = $tempName;
+        unlink($this->dumpDirectory);
+        mkdir($this->dumpDirectory);
+    }
+
+    /** @after */
+    public function removeDumpDir(): void
+    {
+        exec('rm -rf ' . __DIR__ . '/../tmp');
+    }
+}

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -6,16 +6,13 @@ namespace Lcobucci\DependencyInjection;
 use Lcobucci\DependencyInjection\Compiler\DumpXmlContainer;
 use Lcobucci\DependencyInjection\Compiler\ParameterBag;
 use Lcobucci\DependencyInjection\Config\ContainerConfiguration;
+use Lcobucci\DependencyInjection\Generators\Yaml;
 use org\bovigo\vfs\vfsStream;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symfony\Component\Config\ConfigCache;
-use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyBuilder;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 /**
  * @coversDefaultClass \Lcobucci\DependencyInjection\Generator
@@ -24,17 +21,13 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  * @uses \Lcobucci\DependencyInjection\Compiler
  * @uses \Lcobucci\DependencyInjection\Compiler\ParameterBag
  * @uses \Lcobucci\DependencyInjection\Compiler\DumpXmlContainer
+ * @uses \Lcobucci\DependencyInjection\Generators\Yaml
  */
 final class GeneratorTest extends TestCase
 {
-    /** @var Generator&MockObject */
-    private Generator $generator;
+    use GeneratesDumpDirectory;
 
-    /** @before */
-    public function configureDependencies(): void
-    {
-        $this->generator = $this->getMockForAbstractClass(Generator::class, [__FILE__]);
-    }
+    private const DI_NAMESPACE = 'Lcobucci\\DiTests\\Generator';
 
     /**
      * @test
@@ -44,7 +37,9 @@ final class GeneratorTest extends TestCase
      */
     public function initializeContainerShouldAddTheConfigurationFileAsAResource(): void
     {
-        $container = $this->generator->initializeContainer(new ContainerConfiguration('Me\\MyApp'));
+        $container = (new Yaml(__FILE__))->initializeContainer(
+            new ContainerConfiguration(self::DI_NAMESPACE)
+        );
 
         self::assertEquals([new FileResource(__FILE__)], $container->getResources());
     }
@@ -66,34 +61,23 @@ final class GeneratorTest extends TestCase
         );
 
         $config = new ContainerConfiguration(
-            'Me\\MyApp',
+            self::DI_NAMESPACE,
             [vfsStream::url('tests/services.yml')],
             [
                 [new ParameterBag(['app.devmode' => true]), PassConfig::TYPE_BEFORE_OPTIMIZATION],
                 [
-                    new DumpXmlContainer(
-                        new ConfigCache(vfsStream::url('tests/dump.xml'), true)
-                    ),
+                    new DumpXmlContainer(new ConfigCache($this->dumpDirectory . '/dump.xml', true)),
                     PassConfig::TYPE_AFTER_REMOVING,
                     -255,
                 ],
             ]
         );
 
-        $dump = new ConfigCache(vfsStream::url('tests/container.php'), false);
+        $dump = new ConfigCache($this->dumpDirectory . '/container.php', false);
 
-        $this->generator->method('getLoader')->willReturnCallback(
-            static function (SymfonyBuilder $container, array $paths): YamlFileLoader {
-                return new YamlFileLoader(
-                    $container,
-                    new FileLocator($paths)
-                );
-            }
-        );
-
-        $container = $this->generator->generate($config, $dump);
+        $container = (new Yaml(__FILE__))->generate($config, $dump);
 
         self::assertInstanceOf(stdClass::class, $container->get('testing'));
-        self::assertFileExists(vfsStream::url('tests/dump.xml'));
+        self::assertFileExists($this->dumpDirectory . '/dump.xml');
     }
 }


### PR DESCRIPTION
Since the introduction of the container namespace, we must explicitly set the FQCN of the base class (with its leading slash).

Without that, Symfony generates a dump pointing to the wrong class.