### PR TITLE
Only run tests against development dependencies on cron

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,11 +3,12 @@ name: "PHPUnit tests"
 on:
   pull_request:
   push:
+  schedule:
+    - cron: '30 6 * * *'
 
 jobs:
   phpunit:
     name: "PHPUnit tests"
-
     runs-on: ${{ matrix.operating-system }}
 
     strategy:
@@ -16,11 +17,9 @@ jobs:
           - "lowest"
           - "highest"
           - "locked"
-          - "development"
         php-version:
           - "8.2"
-        operating-system:
-          - "ubuntu-latest"
+        operating-system: ["ubuntu-latest"]
 
     steps:
       - name: "Checkout"
@@ -64,19 +63,57 @@ jobs:
       - name: "Tests"
         run: "make phpunit"
 
-  phpunit-rc:
-    name: "PHPUnit tests on php-dev"
+  phpunit-unstable-dependencies:
+    if: github.event.schedule == '30 6 * * *'
 
+    name: "PHPUnit tests"
     runs-on: ${{ matrix.operating-system }}
 
     strategy:
       matrix:
-        dependencies:
-          - "locked"
-        php-version:
-          - "8.3"
-        operating-system:
-          - "ubuntu-latest"
+        dependencies: ["development"]
+        php-version: ["8.2"]
+        operating-system: ["ubuntu-latest"]
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@2.24.0"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          ini-values: memory_limit=-1
+          tools: composer:v2, cs2pr
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: "Cache dependencies"
+        uses: "actions/cache@v3.3.1"
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+
+      - name: "Install development dependencies"
+        if: ${{ matrix.dependencies == 'development' }}
+        run: "composer config minimum-stability dev && composer update --no-interaction --no-progress"
+
+      - name: "Tests"
+        run: "make phpunit"
+
+  phpunit-rc:
+    name: "PHPUnit tests on php-dev"
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        dependencies: ["locked"]
+        php-version: ["8.3"]
+        operating-system: ["ubuntu-latest"]
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
This reduces the amount of items we run on PRs, avoiding pushing deprecation issues to contributors.