### PR TITLE
Support profile specific configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,7 @@ $testContainer = $builder->getTestContainer();
 * `ContainerBuilder#addPass()`: Adds an instance of a [Compiler Pass](compiler-passes.md) to be processed
 * `ContainerBuilder#addDelayedPass()`: Adds a reference (class name and constructor arguments) of a [Compiler Pass](compiler-passes.md) to be processed
 * `ContainerBuilder#addPackage()`: Adds a reference (class name and constructor arguments) of a [Package](packages.md) to be processed
-* `ContainerBuilder#useDevelopmentMode()`: Optimises the generate container for development purposes (configures the compiler to track file changes and update the cache)
+* `ContainerBuilder#enableDebugging()`: Configures the compiler to track file changes and update the cache, optimised for local development purposes
 * `ContainerBuilder#setDumpDir()`: Configures the directory to be used to dump the cache files
 * `ContainerBuilder#setParameter()`: Configures a dynamic parameter
 * `ContainerBuilder#setBaseClass()`: Modifies which class should be used as base class for the container
@@ -59,8 +59,8 @@ require __DIR__ . '/../vendor/autoload.php';
 $builder     = ContainerBuilder::xml(__FILE__, __NAMESPACE__);
 $projectRoot = dirname(__DIR__);
 
-if (getenv('APPLICATION_MODE', true) === 'development') {
-    $builder->useDevelopmentMode();
+if (getenv('APP_PROFILE') !== 'prod') {
+    $builder->enableDebugging();
 }
 
 return $builder->setDumpDir($projectRoot . '/var/tmp')

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ $testContainer = $builder->getTestContainer();
 * `ContainerBuilder#setDumpDir()`: Configures the directory to be used to dump the cache files
 * `ContainerBuilder#setParameter()`: Configures a dynamic parameter
 * `ContainerBuilder#setBaseClass()`: Modifies which class should be used as base class for the container
+* `ContainerBuilder#setProfileName()`: Enables the loading of application profile-specific services via the `when@{profile-name}` syntax
 
 ## Configuration file example
 
@@ -63,7 +64,8 @@ if (getenv('APP_PROFILE') !== 'prod') {
     $builder->enableDebugging();
 }
 
-return $builder->setDumpDir($projectRoot . '/var/tmp')
+return $builder->setProfileName(getenv('APP_PROFILE'))
+               ->setDumpDir($projectRoot . '/var/tmp')
                ->setParameter('app.basedir', $projectRoot)
                ->addFile(__DIR__ . '/container.xml')
                ->getContainer();

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -54,6 +54,11 @@ interface Builder
     public function addPackage(string $className, array $constructArguments = []): Builder;
 
     /**
+     * Configures the application profile name to support profile-specific services
+     */
+    public function setProfileName(string $profileName): Builder;
+
+    /**
      * Mark the container to be used as development mode
      *
      * @deprecated this method will be removed in favour of a more explicit name.

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -55,8 +55,17 @@ interface Builder
 
     /**
      * Mark the container to be used as development mode
+     *
+     * @deprecated this method will be removed in favour of a more explicit name.
+     *
+     * @see enableDebugging
      */
     public function useDevelopmentMode(): Builder;
+
+    /**
+     * Configure the container to track file updates
+     */
+    public function enableDebugging(): Builder;
 
     /**
      * Configures the dump directory

--- a/src/Config/ContainerConfiguration.php
+++ b/src/Config/ContainerConfiguration.php
@@ -31,6 +31,8 @@ final class ContainerConfiguration
 
     private string $dumpDir;
 
+    private ?string $profileName = null;
+
     /**
      * phpcs:disable Generic.Files.LineLength
      *
@@ -49,6 +51,16 @@ final class ContainerConfiguration
         private array $packages = [],
     ) {
         $this->dumpDir = sys_get_temp_dir();
+    }
+
+    public function setProfileName(string $profileName): void
+    {
+        $this->profileName = $profileName;
+    }
+
+    public function profileName(): ?string
+    {
+        return $this->profileName;
     }
 
     /** @return Package[] */
@@ -183,6 +195,7 @@ final class ContainerConfiguration
     {
         return $this->dumpDir . DIRECTORY_SEPARATOR
              . strtolower(str_replace('\\', '_', $this->namespace)) . DIRECTORY_SEPARATOR
+             . ($this->profileName !== null ? $this->profileName . DIRECTORY_SEPARATOR : '')
              . self::CLASS_NAME . '.php';
     }
 

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -144,6 +144,13 @@ final class ContainerBuilder implements Builder
         return $this;
     }
 
+    public function setProfileName(string $profileName): Builder
+    {
+        $this->config->setProfileName($profileName);
+
+        return $this;
+    }
+
     public function useDevelopmentMode(): Builder
     {
         return $this->enableDebugging();

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -38,11 +38,11 @@ final class ContainerBuilder implements Builder
         return self::xml($configurationFile, $namespace);
     }
 
-    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    /** @param class-string<SymfonyBuilder> $builderClass */
     public static function xml(
         string $configurationFile,
         string $namespace,
-        ?string $builderClass = null,
+        string $builderClass = SymfonyBuilder::class,
     ): self {
         return new self(
             new ContainerConfiguration($namespace),
@@ -51,11 +51,11 @@ final class ContainerBuilder implements Builder
         );
     }
 
-    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    /** @param class-string<SymfonyBuilder> $builderClass */
     public static function php(
         string $configurationFile,
         string $namespace,
-        ?string $builderClass = null,
+        string $builderClass = SymfonyBuilder::class,
     ): self {
         return new self(
             new ContainerConfiguration($namespace),
@@ -64,11 +64,11 @@ final class ContainerBuilder implements Builder
         );
     }
 
-    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    /** @param class-string<SymfonyBuilder> $builderClass */
     public static function yaml(
         string $configurationFile,
         string $namespace,
-        ?string $builderClass = null,
+        string $builderClass = SymfonyBuilder::class,
     ): self {
         return new self(
             new ContainerConfiguration($namespace),
@@ -77,11 +77,11 @@ final class ContainerBuilder implements Builder
         );
     }
 
-    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    /** @param class-string<SymfonyBuilder> $builderClass */
     public static function delegating(
         string $configurationFile,
         string $namespace,
-        ?string $builderClass = null,
+        string $builderClass = SymfonyBuilder::class,
     ): self {
         return new self(
             new ContainerConfiguration($namespace),

--- a/src/ContainerBuilder.php
+++ b/src/ContainerBuilder.php
@@ -146,6 +146,11 @@ final class ContainerBuilder implements Builder
 
     public function useDevelopmentMode(): Builder
     {
+        return $this->enableDebugging();
+    }
+
+    public function enableDebugging(): Builder
+    {
         $this->parameterBag->set('app.devmode', true);
 
         return $this;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -51,7 +51,7 @@ abstract class Generator
         $container = new $this->builderClass();
         $container->addResource(new FileResource($this->configurationFile));
 
-        $loader = $this->getLoader($container, $config->getPaths());
+        $loader = $this->getLoader($container, $config->getPaths(), $config->profileName());
 
         foreach ($config->getFiles() as $file) {
             $loader->load($file);
@@ -61,5 +61,9 @@ abstract class Generator
     }
 
     /** @param string[] $paths */
-    abstract public function getLoader(SymfonyBuilder $container, array $paths): LoaderInterface;
+    abstract public function getLoader(
+        SymfonyBuilder $container,
+        array $paths,
+        ?string $profileName = null,
+    ): LoaderInterface;
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -16,16 +16,13 @@ use function is_a;
 abstract class Generator
 {
     private Compiler $compiler;
-    /** @var class-string<SymfonyBuilder> */
-    private string $builderClass;
 
-    /** @param class-string<SymfonyBuilder>|null $builderClass */
+    /** @param class-string<SymfonyBuilder> $builderClass */
     public function __construct(
-        private string $configurationFile,
-        ?string $builderClass = null,
+        private readonly string $configurationFile,
+        private readonly string $builderClass = SymfonyBuilder::class,
     ) {
-        $this->compiler     = new Compiler();
-        $this->builderClass = $builderClass ?? SymfonyBuilder::class;
+        $this->compiler = new Compiler();
     }
 
     /**

--- a/src/Generators/Delegating.php
+++ b/src/Generators/Delegating.php
@@ -19,16 +19,16 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 final class Delegating extends Generator
 {
     /** @inheritDoc */
-    public function getLoader(SymfonyBuilder $container, array $paths): LoaderInterface
+    public function getLoader(SymfonyBuilder $container, array $paths, ?string $profileName = null): LoaderInterface
     {
         $locator = new FileLocator($paths);
 
         return new DelegatingLoader(
             new LoaderResolver(
                 [
-                    new XmlFileLoader($container, $locator),
-                    new YamlFileLoader($container, $locator),
-                    new PhpFileLoader($container, $locator),
+                    new XmlFileLoader($container, $locator, $profileName),
+                    new YamlFileLoader($container, $locator, $profileName),
+                    new PhpFileLoader($container, $locator, $profileName),
                 ],
             ),
         );

--- a/src/Generators/Php.php
+++ b/src/Generators/Php.php
@@ -15,11 +15,12 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 final class Php extends Generator
 {
     /** @inheritDoc */
-    public function getLoader(SymfonyBuilder $container, array $paths): LoaderInterface
+    public function getLoader(SymfonyBuilder $container, array $paths, ?string $profileName = null): LoaderInterface
     {
         return new PhpFileLoader(
             $container,
             new FileLocator($paths),
+            $profileName,
         );
     }
 }

--- a/src/Generators/Xml.php
+++ b/src/Generators/Xml.php
@@ -15,11 +15,12 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 final class Xml extends Generator
 {
     /** @inheritDoc */
-    public function getLoader(SymfonyBuilder $container, array $paths): LoaderInterface
+    public function getLoader(SymfonyBuilder $container, array $paths, ?string $profileName = null): LoaderInterface
     {
         return new XmlFileLoader(
             $container,
             new FileLocator($paths),
+            $profileName,
         );
     }
 }

--- a/src/Generators/Yaml.php
+++ b/src/Generators/Yaml.php
@@ -15,11 +15,12 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 final class Yaml extends Generator
 {
     /** @inheritDoc */
-    public function getLoader(SymfonyBuilder $container, array $paths): LoaderInterface
+    public function getLoader(SymfonyBuilder $container, array $paths, ?string $profileName = null): LoaderInterface
     {
         return new YamlFileLoader(
             $container,
             new FileLocator($paths),
+            $profileName,
         );
     }
 }

--- a/test/Config/ContainerConfigurationTest.php
+++ b/test/Config/ContainerConfigurationTest.php
@@ -290,6 +290,19 @@ final class ContainerConfigurationTest extends TestCase
     }
 
     #[PHPUnit\Test]
+    public function getDumpFileShouldIncludeProfileNameWhenItIsSet(): void
+    {
+        $config = new ContainerConfiguration('Me\\MyApp');
+        $config->setProfileName('prod');
+
+        self::assertEquals(
+            sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'me_myapp' . DIRECTORY_SEPARATOR
+            . 'prod' . DIRECTORY_SEPARATOR . 'AppContainer.php',
+            $config->getDumpFile(),
+        );
+    }
+
+    #[PHPUnit\Test]
     public function getDumpOptionsShouldReturnTheDumpingInformation(): void
     {
         $config  = new ContainerConfiguration('Me\\MyApp');
@@ -356,5 +369,17 @@ final class ContainerConfigurationTest extends TestCase
 
         self::assertSame('Me\\MyApp\\AppContainer', $config->getClassName());
         self::assertSame('Me\\MyApp\\Testing\\AppContainer', $other->getClassName());
+    }
+
+    #[PHPUnit\Test]
+    public function profileNameShouldBeConfigurable(): void
+    {
+        $config = new ContainerConfiguration('Me\\MyApp');
+
+        self::assertNull($config->profileName());
+
+        $config->setProfileName('test');
+
+        self::assertSame('test', $config->profileName());
     }
 }

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -177,11 +177,11 @@ final class ContainerBuilderTest extends TestCase
     }
 
     #[PHPUnit\Test]
-    public function useDevelopmentModeShouldChangeTheParameterAndReturnSelf(): void
+    public function enableDebuggingShouldChangeTheParameterAndReturnSelf(): void
     {
         $builder = new ContainerBuilder($this->config, $this->generator, $this->parameterBag);
 
-        self::assertSame($builder, $builder->useDevelopmentMode());
+        self::assertSame($builder, $builder->enableDebugging());
         self::assertTrue($this->parameterBag->get('app.devmode'));
     }
 

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -232,4 +232,13 @@ final class ContainerBuilderTest extends TestCase
         self::assertCount(1, $compilerPasses);
         self::assertSame($this->parameterBag, $compilerPasses[0][0]);
     }
+
+    #[PHPUnit\Test]
+    public function profileNameShouldBeConfigurable(): void
+    {
+        $builder = new ContainerBuilder($this->config, $this->generator, $this->parameterBag);
+        $builder->setProfileName('testing');
+
+        self::assertSame('testing', $this->config->profileName());
+    }
 }

--- a/test/ContainerBuilderTest.php
+++ b/test/ContainerBuilderTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use function get_class;
@@ -43,7 +44,7 @@ final class ContainerBuilderTest extends TestCase
     public function namedConstructorsShouldSimplifyTheObjectCreation(
         string $method,
         Generator $generator,
-        ?string $builderClass = null,
+        string $builderClass = SymfonyBuilder::class,
     ): void {
         $expected = new ContainerBuilder(
             new ContainerConfiguration('Lcobucci\\DependencyInjection'),


### PR DESCRIPTION
Symfony has the `when@{profile-name}` syntax to load/override services for an application profile (Symfony calls it environment).

This ensures that users can have that functionality if they choose to.