### PR TITLE
Fix codecov integration by passing the token

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -59,3 +59,5 @@ jobs:
 
       - name: "Upload Code Coverage"
         uses: "codecov/codecov-action@v6.0.0"
+        with:
+          token: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
Just a teeny tiny fix